### PR TITLE
feat: セクターのリスト、追加、編集機能を追加

### DIFF
--- a/backend/modules/web/src/main/kotlin/com/example/stock/SectorController.kt
+++ b/backend/modules/web/src/main/kotlin/com/example/stock/SectorController.kt
@@ -2,19 +2,75 @@ package com.example.stock
 
 import com.example.stock.model.Sector
 import com.example.stock.service.SectorService
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.*
 
+/**
+ * セクター情報に関するRESTful APIを提供します。
+ */
 @RestController
 @RequestMapping("/api")
 class SectorController(
     private val sectorService: SectorService
 ) {
+    /**
+     * すべてのセクターのリストを取得します。
+     * @return セクターのリスト
+     */
     @GetMapping("/sectors")
-    fun getSectors(): ResponseEntity<List<Sector>> {
-        val sectors = sectorService.findAll()
-        return ResponseEntity.ok(sectors)
+    fun getSectors(): List<Sector> {
+        return sectorService.findAll()
+    }
+
+    /**
+     * IDを指定してセクターを取得します。
+     * @param id 取得するセクターのID
+     * @return 見つかったセクター。見つからない場合は404 Not Found。
+     */
+    @GetMapping("/sector/{id}")
+    fun getSector(@PathVariable id: Int): ResponseEntity<Sector> {
+        val sector = sectorService.findById(id)
+        return if (sector != null) {
+            ResponseEntity.ok(sector)
+        } else {
+            ResponseEntity.notFound().build()
+        }
+    }
+
+    /**
+     * 新しいセクターを作成します。
+     * @param sector 作成するセクターの情報
+     * @return 作成されたセクターの情報
+     */
+    @PostMapping("/sector")
+    fun createSector(@Validated @RequestBody sector: Sector): ResponseEntity<Sector> {
+        val savedSector = sectorService.save(sector)
+        return ResponseEntity(savedSector, HttpStatus.CREATED)
+    }
+
+    /**
+     * 既存のセクターを更新します。
+     * @param id 更新するセクターのID
+     * @param sector 更新後のセクターの情報
+     * @return 更新されたセクターの情報
+     */
+    @PutMapping("/sector/{id}")
+    fun updateSector(@PathVariable id: Int, @Validated @RequestBody sector: Sector): ResponseEntity<Sector> {
+        val sectorToUpdate = sector.copy(id = id)
+        val updatedSector = sectorService.save(sectorToUpdate)
+        return ResponseEntity.ok(updatedSector)
+    }
+
+    /**
+     * 指定されたIDのセクターを削除します。
+     * @param id 削除するセクターのID
+     * @return レスポンスエンティティ
+     */
+    @DeleteMapping("/sector/{id}")
+    fun deleteSector(@PathVariable id: Int): ResponseEntity<Void> {
+        sectorService.deleteById(id)
+        return ResponseEntity.noContent().build()
     }
 }

--- a/frontend/src/components/common/Header.vue
+++ b/frontend/src/components/common/Header.vue
@@ -9,6 +9,7 @@ export default {
     return {
       // ナビゲーションアイテムの配列
       navItems: [
+        { name: 'セクター管理', path: '/sectors' },
         { name: 'オーナー管理', path: '/owner' },
         { name: '銘柄管理', path: '/stock' }
       ]

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -2,11 +2,13 @@ import { createRouter, createWebHistory } from 'vue-router';
 import OwnerList from '../views/owner/List.vue';
 import StockList from '../views/stock/List.vue';
 import StockAddEdit from '../views/stock/AddEdit.vue';
+import SectorList from '../views/sector/List.vue';
+import SectorAddEdit from '../views/sector/AddEdit.vue';
 
 const routes = [
   {
     path: '/',
-    redirect: '/owner'
+    redirect: '/sectors'
   },
   {
     path: '/owner',
@@ -27,6 +29,22 @@ const routes = [
     path: '/stock/edit/:id',
     name: 'StockEdit',
     component: StockAddEdit,
+    props: true
+  },
+  {
+    path: '/sectors',
+    name: 'SectorList',
+    component: SectorList
+  },
+  {
+    path: '/sector/add',
+    name: 'SectorAdd',
+    component: SectorAddEdit
+  },
+  {
+    path: '/sector/edit/:id',
+    name: 'SectorEdit',
+    component: SectorAddEdit,
     props: true
   }
 ];

--- a/frontend/src/views/sector/AddEdit.vue
+++ b/frontend/src/views/sector/AddEdit.vue
@@ -1,0 +1,77 @@
+<template src="./templates/SectorAddEdit.html"></template>
+
+<script>
+import axios from 'axios';
+
+export default {
+  name: 'SectorAddEdit',
+  props: {
+    id: {
+      type: [String, Number],
+      default: null
+    }
+  },
+  data() {
+    return {
+      formData: {
+        name: ''
+      },
+      sector: null
+    };
+  },
+  computed: {
+    isEditing() {
+      return this.id != null;
+    },
+    pageTitle() {
+      return this.isEditing ? 'セクター編集' : '新規セクター追加';
+    }
+  },
+  methods: {
+    async fetchSector() {
+      if (!this.isEditing) {
+        this.sector = {}; // 新規作成モード
+        return;
+      }
+      try {
+        const response = await axios.get(`/api/sector/${this.id}`);
+        this.sector = response.data;
+        this.formData.name = this.sector.name;
+      } catch (error) {
+        console.error('セクターの取得中にエラーが発生しました:', error);
+        this.$router.push('/sectors'); // エラー時はリストにリダイレクト
+      }
+    },
+    async saveSector() {
+      try {
+        const sectorData = {
+          name: this.formData.name
+        };
+
+        if (this.isEditing) {
+          await axios.put(`/api/sector/${this.id}`, { ...sectorData, id: parseInt(this.id) });
+        } else {
+          await axios.post('/api/sector', sectorData);
+        }
+
+        this.$router.push('/sectors');
+      } catch (error) {
+        console.error('セクターの保存中にエラーが発生しました:', error);
+        alert('保存に失敗しました。もう一度お試しください。');
+      }
+    },
+    cancel() {
+      this.$router.push('/sectors');
+    }
+  },
+  created() {
+    this.fetchSector();
+  },
+  watch: {
+    // ルートのIDが変更された場合（例：編集ページから別の編集ページへ移動）、データを再取得
+    '$route.params.id'() {
+        this.fetchSector();
+    }
+  }
+};
+</script>

--- a/frontend/src/views/sector/List.vue
+++ b/frontend/src/views/sector/List.vue
@@ -1,0 +1,51 @@
+<template src="./templates/SectorList.html"></template>
+
+<script>
+import axios from 'axios';
+
+export default {
+  // コンポーネント名を'SectorList'に設定
+  name: 'SectorList',
+  // コンポーネントのデータ
+  data() {
+    return {
+      // セクターのリスト
+      sectors: [],
+    };
+  },
+  // メソッド
+  methods: {
+    // APIからセクターのリストを取得
+    async fetchSectors() {
+      try {
+        const response = await axios.get('/api/sectors');
+        this.sectors = response.data;
+      } catch (error) {
+        console.error('セクターの取得中にエラーが発生しました:', error);
+      }
+    },
+    goToAddPage() {
+      this.$router.push('/sector/add');
+    },
+    goToEditPage(id) {
+      this.$router.push(`/sector/edit/${id}`);
+    },
+    async deleteSector(id) {
+      if (confirm('このセクターを削除しますか？')) {
+        try {
+          // バックエンドAPIのパスを修正
+          await axios.delete(`/api/sector/${id}`);
+          this.fetchSectors(); // リストを再読み込み
+        } catch (error) {
+          console.error('セクターの削除中にエラーが発生しました:', error);
+          alert('削除に失敗しました。');
+        }
+      }
+    }
+  },
+
+  mounted() {
+    this.fetchSectors();
+  }
+};
+</script>

--- a/frontend/src/views/sector/templates/SectorAddEdit.html
+++ b/frontend/src/views/sector/templates/SectorAddEdit.html
@@ -1,0 +1,18 @@
+<div class="form-container">
+  <h3 class="form-title">{{ pageTitle }}</h3>
+
+  <form @submit.prevent="saveSector" class="form-inline">
+    <input
+      type="text"
+      v-model="formData.name"
+      placeholder="名前"
+      required
+      class="form-control"
+    >
+
+    <div class="form-actions">
+      <button type="submit" class="btn btn-success">保存</button>
+      <button type="button" class="btn btn-secondary" @click="cancel">キャンセル</button>
+    </div>
+  </form>
+</div>

--- a/frontend/src/views/sector/templates/SectorList.html
+++ b/frontend/src/views/sector/templates/SectorList.html
@@ -1,0 +1,39 @@
+<!-- セクター管理ページのコンテナ -->
+<div>
+  <!-- ページヘッダー -->
+  <div class="page-header">
+    <h1 class="page-title">セクター管理</h1>
+  </div>
+
+  <!-- ページアクション -->
+  <div class="page-actions">
+    <!-- 新規セクター追加ボタン -->
+    <button class="btn btn-primary" @click="goToAddPage">
+      新規セクター追加
+    </button>
+  </div>
+
+  <!-- セクターを表示するためのテーブル -->
+  <table class="common-table">
+    <!-- テーブルヘッダー -->
+    <thead>
+      <tr>
+        <th>名前</th>
+        <th>操作</th>
+      </tr>
+    </thead>
+    <!-- テーブルボディ -->
+    <tbody>
+      <!-- セクター情報をループで表示 -->
+      <tr v-for="sector in sectors" :key="sector.id">
+        <td>{{ sector.name }}</td>
+        <td>
+          <!-- 編集ボタン -->
+          <button class="btn btn-secondary btn-sm" @click="goToEditPage(sector.id)">編集</button>
+          <!-- 削除ボタン -->
+          <button class="btn btn-danger btn-sm" @click="deleteSector(sector.id)">削除</button>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>


### PR DESCRIPTION
バックエンドとフロントエンドに、セクター（Sector）のCRUD（作成、読み取り、更新、削除）機能を追加しました。

バックエンド:
- `SectorController` に、セクターの取得（ID指定）、作成、更新、削除を行うためのREST APIエンドポイントを実装しました。
- APIパスは `/api/sector` および `/api/sectors` です。

フロントエンド:
- セクター一覧を表示する `SectorList.vue` を作成しました。
- セクターの追加・編集を行う `SectorAddEdit.vue` を作成しました。
- 上記コンポーネント用のHTMLテンプレートを追加しました。
- `router/index.js` にセクター管理画面用のルートを追加しました。
- アプリケーションのヘッダーに「セクター管理」へのナビゲーションリンクを追加しました。