### PR TITLE
Fix(stock): Update stock provider to handle Yahoo Finance changes

### DIFF
--- a/backend/modules/stock/src/main/kotlin/com/example/stock/provider/YahooFinanceProvider.kt
+++ b/backend/modules/stock/src/main/kotlin/com/example/stock/provider/YahooFinanceProvider.kt
@@ -1,7 +1,5 @@
 package com.example.stock.provider
 
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.ObjectMapper
 import org.jsoup.Jsoup
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
@@ -16,10 +14,7 @@ class YahooFinanceProvider(
 
     companion object {
         private const val BASE_URL = "https://finance.yahoo.co.jp/quote"
-        private const val PRELOADED_STATE_PREFIX = "window.__PRELOADED_STATE__ = "
     }
-
-    private val objectMapper = ObjectMapper()
 
     override fun fetchStockInfo(code: String): StockInfo? {
         // リクエスト間の遅延を挿入して、サーバーへの負荷を軽減します。
@@ -28,11 +23,10 @@ class YahooFinanceProvider(
         return try {
             val url = "$BASE_URL/$code.T"
             val doc = Jsoup.connect(url).get()
-            val preloadedState = getPreloadedState(doc)
 
-            val price = extractPrice(preloadedState)
-            val dividend = extractDividend(preloadedState)
-            val earningsDate = extractEarningsDate(preloadedState)
+            val price = extractPrice(doc)
+            val dividend = extractDividend(doc)
+            val earningsDate = extractEarningsDate(doc)
 
             StockInfo(price, dividend, earningsDate)
         } catch (e: Exception) {
@@ -48,39 +42,29 @@ class YahooFinanceProvider(
         return try {
             val url = "$BASE_URL/$code.T"
             val doc = Jsoup.connect(url).get()
-            val preloadedState = getPreloadedState(doc)
-            extractName(preloadedState)
+            extractName(doc)
         } catch (e: Exception) {
             e.printStackTrace()
             null
         }
     }
 
-    private fun getPreloadedState(doc: org.jsoup.nodes.Document): JsonNode? {
-        val scriptElements = doc.getElementsByTag("script")
-        val script = scriptElements.find { it.html().trim().startsWith(PRELOADED_STATE_PREFIX) }
-            ?: return null
-        val jsonText = script.html().trim().removePrefix(PRELOADED_STATE_PREFIX)
-        return objectMapper.readTree(jsonText)
+    private fun extractName(doc: org.jsoup.nodes.Document): String? {
+        return doc.selectFirst("""div[data-testid="stock-name"]""")?.text()
     }
 
-    private fun extractName(jsonNode: JsonNode?): String? {
-        return jsonNode?.at("/mainStocksPriceBoard/priceBoard/name")?.asText()
+    private fun extractPrice(doc: org.jsoup.nodes.Document): Double? {
+        val priceText = doc.selectFirst("""div[data-testid="stock-price"]""")?.text()?.replace(",", "")
+        return priceText?.toDoubleOrNull()
     }
 
-    private fun extractPrice(jsonNode: JsonNode?): Double? {
-        return jsonNode?.at("/mainStocksPriceBoard/priceBoard/price")?.asDouble()
+    private fun extractDividend(doc: org.jsoup.nodes.Document): Double? {
+        val dividendElement = doc.select("dt").find { it.text() == "配当利回り（会社予想）" }
+        return dividendElement?.nextElementSibling()?.text()?.removeSuffix("%")?.toDoubleOrNull()
     }
 
-    private fun extractDividend(jsonNode: JsonNode?): Double? {
-        // "dps" in referenceIndex seems to be "Dividend Per Share"
-        return jsonNode?.at("/mainStocksDetail/referenceIndex/dps")?.asText()?.toDoubleOrNull()
-    }
-
-    private fun extractEarningsDate(jsonNode: JsonNode?): LocalDate? {
-        val earningsText = jsonNode?.at("/mainStocksPressReleaseSchedule/pressReleaseScheduleMessage")?.asText()
-            ?: return null
-
+    private fun extractEarningsDate(doc: org.jsoup.nodes.Document): LocalDate? {
+        val earningsText = doc.select("p:contains(直近の決算発表日は)").text()
         val pattern = Pattern.compile("(\\d{4})年(\\d{1,2})月(\\d{1,2})日")
         val matcher = pattern.matcher(earningsText)
 

--- a/backend/modules/stock/src/test/kotlin/com/example/stock/provider/YahooFinanceProviderTest.kt
+++ b/backend/modules/stock/src/test/kotlin/com/example/stock/provider/YahooFinanceProviderTest.kt
@@ -1,10 +1,13 @@
 package com.example.stock.provider
 
-import com.fasterxml.jackson.databind.JsonNode
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.jsoup.Connection
 import org.jsoup.Jsoup
+import org.mockito.MockedStatic
+import org.mockito.Mockito.*
 import java.io.File
 import java.time.LocalDate
 
@@ -12,59 +15,38 @@ class YahooFinanceProviderTest {
 
     private lateinit var provider: YahooFinanceProvider
     private lateinit var doc: org.jsoup.nodes.Document
+    private lateinit var mockedJsoup: MockedStatic<Jsoup>
 
     @BeforeEach
     fun setUp() {
         provider = YahooFinanceProvider(0) // requestDelayMillis = 0
         val htmlFile = File("src/test/resources/com/example/stock/provider/dummy-yahoo-finance.html")
-        doc = Jsoup.parse(htmlFile, "UTF-8")
+        doc = Jsoup.parse(htmlFile, "UTF-8", "")
+
+        // Mock Jsoup.connect to avoid actual network calls
+        val connection = mock(Connection::class.java)
+        `when`(connection.get()).thenReturn(doc)
+        mockedJsoup = mockStatic(Jsoup::class.java)
+        mockedJsoup.`when`<Connection> { Jsoup.connect(anyString()) }.thenReturn(connection)
     }
 
-    private fun getJsonNode(): JsonNode {
-        val method = provider::class.java.getDeclaredMethod("getPreloadedState", org.jsoup.nodes.Document::class.java)
-        method.isAccessible = true
-        return method.invoke(provider, doc) as JsonNode
+    @AfterEach
+    fun tearDown() {
+        mockedJsoup.close()
     }
 
     @Test
-    fun `getPreloadedState should return json`() {
-        val jsonNode = getJsonNode()
-        assertNotNull(jsonNode)
+    fun `fetchStockInfo should return correct stock info`() {
+        val stockInfo = provider.fetchStockInfo("dummy")
+        assertNotNull(stockInfo)
+        assertEquals(1234.5, stockInfo?.price)
+        assertEquals(50.0, stockInfo?.dividend)
+        assertEquals(LocalDate.of(2025, 10, 31), stockInfo?.earningsDate)
     }
 
     @Test
-    fun `extractName should return correct name`() {
-        val jsonNode = getJsonNode()
-        val method = provider::class.java.getDeclaredMethod("extractName", JsonNode::class.java)
-        method.isAccessible = true
-        val name = method.invoke(provider, jsonNode)
+    fun `fetchStockName should return correct name`() {
+        val name = provider.fetchStockName("dummy")
         assertEquals("テスト株式会社", name)
-    }
-
-    @Test
-    fun `extractPrice should return correct price`() {
-        val jsonNode = getJsonNode()
-        val method = provider::class.java.getDeclaredMethod("extractPrice", JsonNode::class.java)
-        method.isAccessible = true
-        val price = method.invoke(provider, jsonNode)
-        assertEquals(1234.5, price)
-    }
-
-    @Test
-    fun `extractDividend should return correct dividend`() {
-        val jsonNode = getJsonNode()
-        val method = provider::class.java.getDeclaredMethod("extractDividend", JsonNode::class.java)
-        method.isAccessible = true
-        val dividend = method.invoke(provider, jsonNode)
-        assertEquals(50.0, dividend)
-    }
-
-    @Test
-    fun `extractEarningsDate should return correct date`() {
-        val jsonNode = getJsonNode()
-        val method = provider::class.java.getDeclaredMethod("extractEarningsDate", JsonNode::class.java)
-        method.isAccessible = true
-        val date = method.invoke(provider, jsonNode)
-        assertEquals(LocalDate.of(2025, 10, 31), date)
     }
 }

--- a/backend/modules/stock/src/test/resources/com/example/stock/provider/dummy-yahoo-finance.html
+++ b/backend/modules/stock/src/test/resources/com/example/stock/provider/dummy-yahoo-finance.html
@@ -4,23 +4,12 @@
 <title>Test Page</title>
 </head>
 <body>
-<script>
-window.__PRELOADED_STATE__ = {
-  "mainStocksPriceBoard": {
-    "priceBoard": {
-      "name": "テスト株式会社",
-      "price": 1234.5
-    }
-  },
-  "mainStocksDetail": {
-    "referenceIndex": {
-      "dps": "50.0"
-    }
-  },
-  "mainStocksPressReleaseSchedule": {
-    "pressReleaseScheduleMessage": "決算発表予定日 2025年10月31日"
-  }
-}
-</script>
+    <div data-testid="stock-name">テスト株式会社</div>
+    <div data-testid="stock-price">1,234.5</div>
+    <dl>
+        <dt>配当利回り（会社予想）</dt>
+        <dd>50.0%</dd>
+    </dl>
+    <p>直近の決算発表日は2025年10月31日でした。</p>
 </body>
 </html>


### PR DESCRIPTION
The Yahoo Finance Japan website has changed its structure, which broke the existing web scraping logic for fetching stock prices. The previous implementation relied on a `window.__PRELOADED_STATE__` JSON object, which is no longer present in the page source.

This commit updates the `YahooFinanceProvider` to parse the HTML directly using Jsoup and CSS selectors with `data-testid` attributes, which are more stable than auto-generated class names.

The tests for the provider have also been updated to reflect these changes, and now use Mockito to mock the `Jsoup.connect` method, making the tests more robust and independent of network conditions.