### PR TITLE
feat: Enforce 100-share units for transactions

### DIFF
--- a/backend/modules/stock/src/main/kotlin/com/example/stock/service/StockLotService.kt
+++ b/backend/modules/stock/src/main/kotlin/com/example/stock/service/StockLotService.kt
@@ -12,7 +12,24 @@ import org.springframework.transaction.annotation.Transactional
 class StockLotService(
     private val stockLotRepository: StockLotRepository
 ) {
-    fun createStockLot(owner: Owner, stock: Stock, isNisa: Boolean, quantity: Int): StockLot {
+    fun createStockLots(owner: Owner, stock: Stock, isNisa: Boolean, totalQuantity: Int): List<StockLot> {
+        if (totalQuantity % 100 != 0) {
+            throw IllegalArgumentException("Quantity must be a multiple of 100")
+        }
+        val lots = mutableListOf<StockLot>()
+        for (i in 0 until totalQuantity / 100) {
+            val stockLot = StockLot(
+                owner = owner,
+                stock = stock,
+                isNisa = isNisa,
+                quantity = 100
+            )
+            lots.add(stockLotRepository.save(stockLot))
+        }
+        return lots
+    }
+
+    fun createSingleStockLot(owner: Owner, stock: Stock, isNisa: Boolean, quantity: Int): StockLot {
         val stockLot = StockLot(
             owner = owner,
             stock = stock,

--- a/backend/modules/web/src/main/kotlin/com/example/stock/TransactionController.kt
+++ b/backend/modules/web/src/main/kotlin/com/example/stock/TransactionController.kt
@@ -26,9 +26,9 @@ class TransactionController(
     }
 
     @PostMapping
-    fun createTransaction(@Validated @RequestBody request: TransactionAddRequest): ResponseEntity<TransactionDTO> {
-        val createdTransaction = transactionService.createTransaction(request)
-        return ResponseEntity(createdTransaction, HttpStatus.CREATED)
+    fun createTransaction(@Validated @RequestBody request: TransactionAddRequest): ResponseEntity<List<TransactionDTO>> {
+        val createdTransactions = transactionService.createTransaction(request)
+        return ResponseEntity(createdTransactions, HttpStatus.CREATED)
     }
 
     @DeleteMapping("/{id}")

--- a/frontend/src/views/transaction/Buy.vue
+++ b/frontend/src/views/transaction/Buy.vue
@@ -39,6 +39,10 @@ export default {
       }
     },
     async saveTransaction() {
+      if (this.formData.quantity % 100 !== 0) {
+        alert('数量は100の倍数である必要があります。');
+        return;
+      }
       try {
         await axios.post('/api/transaction', this.formData);
         this.$router.push('/transaction');

--- a/frontend/src/views/transaction/templates/Buy.html
+++ b/frontend/src/views/transaction/templates/Buy.html
@@ -42,6 +42,8 @@
         placeholder="数量"
         required
         class="form-control"
+        step="100"
+        min="100"
       >
     </div>
 


### PR DESCRIPTION
This commit introduces a new rule for stock transactions, requiring them to be in multiples of 100 shares. Stock lots are now also created in 100-share units.

On the frontend, the quantity input for buying stocks has been updated to step in increments of 100, and a validation check has been added to ensure compliance.

On the backend, the `TransactionService` now creates multiple transactions and associated `StockLot`s when a user purchases a quantity of shares that is a multiple of 100. For example, a purchase of 300 shares will result in three separate transactions, each for a 100-share lot.

The `StockLotService` has been updated to include a `createStockLots` method that handles the creation of these new lots.

The `TransactionController` and `TransactionServiceTest` have been updated to align with these changes.