### PR TITLE
feat: Add sell from transaction list and fix backend logic

### DIFF
--- a/backend/modules/stock/src/main/kotlin/com/example/stock/dto/TransactionDTO.kt
+++ b/backend/modules/stock/src/main/kotlin/com/example/stock/dto/TransactionDTO.kt
@@ -18,7 +18,8 @@ data class TransactionDTO(
     val owner_name: String,
     val quantity: Int,
     val price: Double,
-    val fees: Double
+    val fees: Double,
+    val lot_id: Int
 )
 
 /**

--- a/backend/modules/stock/src/main/kotlin/com/example/stock/service/TransactionService.kt
+++ b/backend/modules/stock/src/main/kotlin/com/example/stock/service/TransactionService.kt
@@ -36,7 +36,8 @@ class TransactionService(
         owner_name = this.stockLot.owner.name,
         quantity = this.quantity,
         price = this.price.toDouble(),
-        fees = this.tax.toDouble()
+        fees = this.tax.toDouble(),
+        lot_id = this.stockLot.id
     )
 
     fun findAllTransactions(): List<TransactionDTO> {
@@ -85,6 +86,10 @@ class TransactionService(
                 transaction_date = request.date
             )
             transactions.add(transactionRepository.save(transaction))
+
+            // Mark the lot as sold
+            val soldStockLot = stockLot.copy(status = com.example.stock.model.LotStatus.SOLD)
+            stockLotRepository.save(soldStockLot)
         }
 
         return transactions.map { it.toDTO() }

--- a/frontend/src/views/transaction/List.vue
+++ b/frontend/src/views/transaction/List.vue
@@ -22,6 +22,9 @@ export default {
     goToAddTransaction() {
       this.$router.push('/transaction/add');
     },
+    goToSellPage(lotId) {
+      this.$router.push(`/transaction/sell/${lotId}`);
+    },
   },
   mounted() {
     this.fetchTransactions();

--- a/frontend/src/views/transaction/templates/List.html
+++ b/frontend/src/views/transaction/templates/List.html
@@ -17,6 +17,7 @@
         <th>数量</th>
         <th>価格</th>
         <th>手数料</th>
+        <th></th>
       </tr>
     </thead>
     <tbody>
@@ -29,6 +30,14 @@
         <td>{{ transaction.quantity }}</td>
         <td>{{ transaction.price }}</td>
         <td>{{ transaction.fees }}</td>
+        <td>
+          <button
+            v-if="transaction.type === 'BUY'"
+            @click="goToSellPage(transaction.lot_id)"
+            class="btn-sm btn-sell">
+            売却
+          </button>
+        </td>
       </tr>
     </tbody>
   </table>

--- a/frontend/src/views/transaction/templates/Sell.html
+++ b/frontend/src/views/transaction/templates/Sell.html
@@ -22,18 +22,6 @@
     </div>
 
     <div class="form-group">
-      <label for="quantity">数量</label>
-      <input
-        id="quantity"
-        type="number"
-        v-model="formData.quantity"
-        placeholder="数量"
-        required
-        class="form-control"
-      >
-    </div>
-
-    <div class="form-group">
       <label for="price">価格</label>
       <input
         id="price"


### PR DESCRIPTION
This change introduces the ability for users to initiate a sale directly from the transaction history page and fixes the backend logic for selling.

- Adds a "Sell" button to each "BUY" transaction row in the transaction list.
- The button navigates the user to the existing sell page, pre-filled with the correct stock lot information.
- The backend `TransactionDTO` has been updated to include the `lot_id` to facilitate this.
- The quantity input on the sell page has been removed. The entire lot is now sold by default.
- The backend service for creating a "SELL" transaction now correctly updates the `StockLot`'s status to "SOLD".