### PR TITLE
feat: 最低単元数に合わせてStockLotが決まるように修正

### DIFF
--- a/backend/modules/stock/src/main/kotlin/com/example/stock/model/Stock.kt
+++ b/backend/modules/stock/src/main/kotlin/com/example/stock/model/Stock.kt
@@ -41,5 +41,8 @@ data class Stock(
 
     @ManyToOne
     @JoinColumn(name = "sector_id")
-    var sector: Sector? = null // セクター
+    var sector: Sector? = null, // セクター
+
+    @Column(name = "minimum_unit", nullable = false)
+    val minimum_unit: Int = 100 // 最低単元数
 )

--- a/backend/modules/stock/src/main/kotlin/com/example/stock/model/StockLot.kt
+++ b/backend/modules/stock/src/main/kotlin/com/example/stock/model/StockLot.kt
@@ -38,7 +38,7 @@ data class StockLot(
     val stock: Stock, // 銘柄
 
     @Column(name = "quantity", nullable = false)
-    val quantity: Int, // 数量
+    val quantity: Int, // 最低単元数
 
     @Column(name = "is_nisa", nullable = false)
     val isNisa: Boolean = false, // NISAかどうか

--- a/backend/modules/stock/src/main/kotlin/com/example/stock/service/StockLotService.kt
+++ b/backend/modules/stock/src/main/kotlin/com/example/stock/service/StockLotService.kt
@@ -47,16 +47,17 @@ class StockLotService(
      * @throws IllegalArgumentException 株数が100の倍数でない場合
      */
     fun createStockLots(owner: Owner, stock: Stock, isNisa: Boolean, totalQuantity: Int): List<StockLot> {
-        if (totalQuantity % 100 != 0) {
-            throw IllegalArgumentException("Quantity must be a multiple of 100")
+        val minimumUnit = if (stock.minimum_unit == 0) 1 else stock.minimum_unit
+        if (totalQuantity % minimumUnit != 0) {
+            throw IllegalArgumentException("Quantity must be a multiple of ${minimumUnit}")
         }
         val lots = mutableListOf<StockLot>()
-        for (i in 0 until totalQuantity / 100) {
+        for (i in 0 until totalQuantity / minimumUnit) {
             val stockLot = StockLot(
                 owner = owner,
                 stock = stock,
                 isNisa = isNisa,
-                quantity = 100
+                quantity = minimumUnit
             )
             lots.add(stockLotRepository.save(stockLot))
         }

--- a/backend/modules/stock/src/test/kotlin/com/example/stock/service/StockLotServiceTest.kt
+++ b/backend/modules/stock/src/test/kotlin/com/example/stock/service/StockLotServiceTest.kt
@@ -1,0 +1,85 @@
+package com.example.stock.service
+
+import com.example.stock.model.Owner
+import com.example.stock.model.Stock
+import com.example.stock.model.StockLot
+import com.example.stock.repository.StockLotRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentCaptor
+import org.mockito.Captor
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.Mockito.`when` as mockitoWhen
+import org.mockito.ArgumentMatchers.any
+
+@ExtendWith(MockitoExtension::class)
+class StockLotServiceTest {
+
+    @InjectMocks
+    private lateinit var stockLotService: StockLotService
+
+    @Mock
+    private lateinit var stockLotRepository: StockLotRepository
+
+    @Captor
+    private lateinit var stockLotCaptor: ArgumentCaptor<StockLot>
+
+    @Test
+    fun `createStockLots should create lots with minimum unit`() {
+        // given
+        val owner = Owner(id = 1, name = "Test Owner")
+        val stock = Stock(id = 1, code = "1234", name = "Test Stock", minimum_unit = 50)
+        val totalQuantity = 200
+
+        mockitoWhen(stockLotRepository.save(any(StockLot::class.java))).thenAnswer { it.getArgument(0) }
+
+        // when
+        val result = stockLotService.createStockLots(owner, stock, false, totalQuantity)
+
+        // then
+        verify(stockLotRepository, org.mockito.Mockito.times(4)).save(stockLotCaptor.capture())
+        val capturedStockLots = stockLotCaptor.allValues
+
+        assertThat(result).hasSize(4)
+        assertThat(capturedStockLots.all { it.quantity == 50 }).isTrue()
+    }
+
+    @Test
+    fun `createStockLots should throw exception for invalid quantity`() {
+        // given
+        val owner = Owner(id = 1, name = "Test Owner")
+        val stock = Stock(id = 1, code = "1234", name = "Test Stock", minimum_unit = 50)
+        val totalQuantity = 120
+
+        // when & then
+        val exception = assertThrows(IllegalArgumentException::class.java) {
+            stockLotService.createStockLots(owner, stock, false, totalQuantity)
+        }
+        assertThat(exception.message).isEqualTo("Quantity must be a multiple of 50")
+    }
+
+    @Test
+    fun `createStockLots should handle zero minimum unit`() {
+        // given
+        val owner = Owner(id = 1, name = "Test Owner")
+        val stock = Stock(id = 1, code = "1234", name = "Test Stock", minimum_unit = 0)
+        val totalQuantity = 10
+
+        mockitoWhen(stockLotRepository.save(any(StockLot::class.java))).thenAnswer { it.getArgument(0) }
+
+        // when
+        val result = stockLotService.createStockLots(owner, stock, false, totalQuantity)
+
+        // then
+        verify(stockLotRepository, org.mockito.Mockito.times(10)).save(stockLotCaptor.capture())
+        val capturedStockLots = stockLotCaptor.allValues
+
+        assertThat(result).hasSize(10)
+        assertThat(capturedStockLots.all { it.quantity == 1 }).isTrue()
+    }
+}


### PR DESCRIPTION
stockModelに最低単元数を設定できるようにします。
最低単元数に合わせてStockLotが決まります。
つまりstock:Aの最低単元数が100であれば、200株購入すればStockLot:Aは2レコードとなります。

主な変更点：
- `Stock`エンティティに`minimum_unit`フィールドを追加（デフォルトは100）
- `StockLotService`が`minimum_unit`を使用して株式ロットを作成するように変更
- `StockLotService`の新しいテストを追加