### PR TITLE
feat: h2データベースの永続化

### DIFF
--- a/backend/modules/web/src/main/resources/application.yml
+++ b/backend/modules/web/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:db;MODE=MYSQL
+    url: jdbc:h2:file:/data/db;MODE=MYSQL
     driver-class-name: org.h2.Driver
     username: sa
     password: 

--- a/compose.yml
+++ b/compose.yml
@@ -4,6 +4,8 @@ services:
     build: ./backend
     ports:
       - "8080:8080"
+    volumes:
+      - h2-data:/data
     networks:
       - app-network
 
@@ -19,3 +21,6 @@ services:
 networks:
   app-network:
     driver: bridge
+
+volumes:
+  h2-data:


### PR DESCRIPTION
`compose.yml`を修正して、Dockerボリュームを使用しH2データベースのデータを永続化します。

- `backend`サービスに`h2-data`という名前のボリュームをマウントし、コンテナ内の`/data`ディレクトリに接続します。
- `application.yml`のH2接続URLをインメモリからファイルベース(`jdbc:h2:file:/data/db`)に変更し、データがボリュームに保存されるようにします。