### PR TITLE
fix(frontend): Correct invalid class binding in holding list

### DIFF
--- a/frontend/src/views/holding/templates/HoldingList.html
+++ b/frontend/src/views/holding/templates/HoldingList.html
@@ -49,7 +49,7 @@
         <td>{{ holding.dividend }}</td>
         <td>{{ holding.status }}</td>
         <td>
-          <button @click="sellHolding(holding.id)" class.bind="btn btn-success">売却</button>
+          <button @click="sellHolding(holding.id)" class="btn btn-success">売却</button>
         </td>
       </tr>
     </tbody>


### PR DESCRIPTION
The 'sell' button in the holding list view was using `class.bind` to assign CSS classes. This is not valid Vue.js syntax and was likely causing the template compiler to fail, preventing the `@click` event handler from being attached correctly. This resulted in the button not functioning as expected.

This commit corrects the attribute to the standard `class`, which resolves the template syntax error and allows the `sellHolding` method to be called correctly upon clicking the button.