### PR TITLE
Refactor: Remove LotStatus from StockLot entity

### DIFF
--- a/backend/modules/stock/src/main/kotlin/com/example/stock/dto/HoldingInfoDTO.kt
+++ b/backend/modules/stock/src/main/kotlin/com/example/stock/dto/HoldingInfoDTO.kt
@@ -1,6 +1,5 @@
 package com.example.stock.dto
 
-import com.example.stock.model.LotStatus
 import java.math.BigDecimal
 
 data class HoldingInfoDTO(
@@ -12,7 +11,6 @@ data class HoldingInfoDTO(
     val unit: Int,
     val quantity: Int,
     val is_nisa: Boolean,
-    val status: LotStatus,
     val acquisition_price: BigDecimal,
     val current_price: BigDecimal,
     val profit_loss: BigDecimal,

--- a/backend/modules/stock/src/main/kotlin/com/example/stock/dto/StockLotDTO.kt
+++ b/backend/modules/stock/src/main/kotlin/com/example/stock/dto/StockLotDTO.kt
@@ -1,7 +1,5 @@
 package com.example.stock.dto
 
-import com.example.stock.model.LotStatus
-
 /**
  * 株式ロットのデータ転送オブジェクト(DTO)。
  *
@@ -13,7 +11,6 @@ import com.example.stock.model.LotStatus
  * @property unit 単元数
  * @property quantity 株数
  * @property is_nisa NISA口座かどうか
- * @property status ロットのステータス
  */
 data class StockLotDTO(
     val id: Int,
@@ -24,6 +21,5 @@ data class StockLotDTO(
     val unit: Int,
     val quantity: Int,
     val is_nisa: Boolean,
-    val status: LotStatus,
     val minimalUnit: Int
 )

--- a/backend/modules/stock/src/main/kotlin/com/example/stock/model/StockLot.kt
+++ b/backend/modules/stock/src/main/kotlin/com/example/stock/model/StockLot.kt
@@ -8,17 +8,6 @@ import jakarta.persistence.Id
 import jakarta.persistence.Column
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.JoinColumn
-import jakarta.persistence.Enumerated
-import jakarta.persistence.EnumType
-
-/**
- * 保有状況
- */
-enum class LotStatus {
-    HOLDING, // 保有
-    SOLD     // 売却済み
-}
-
 /**
  * 株式ロット エンティティ
  */
@@ -41,9 +30,5 @@ data class StockLot(
     val unit: Int, // 単元数
 
     @Column(name = "is_nisa", nullable = false)
-    val isNisa: Boolean = false, // NISAかどうか
-
-    @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false)
-    val status: LotStatus = LotStatus.HOLDING // 保有状況
+    val isNisa: Boolean = false // NISAかどうか
 )

--- a/backend/modules/stock/src/main/kotlin/com/example/stock/repository/StockLotRepository.kt
+++ b/backend/modules/stock/src/main/kotlin/com/example/stock/repository/StockLotRepository.kt
@@ -1,6 +1,5 @@
 package com.example.stock.repository
 
-import com.example.stock.model.LotStatus
 import com.example.stock.model.StockLot
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
@@ -8,8 +7,4 @@ import org.springframework.stereotype.Repository
 @Repository
 interface StockLotRepository : JpaRepository<StockLot, Int> {
     fun findByOwnerId(ownerId: Int): List<StockLot>
-
-    fun findByStatus(status: LotStatus): List<StockLot>
-
-    fun findByOwnerIdAndStatus(ownerId: Int, status: LotStatus): List<StockLot>
 }

--- a/backend/modules/stock/src/main/kotlin/com/example/stock/service/IncomingHistoryService.kt
+++ b/backend/modules/stock/src/main/kotlin/com/example/stock/service/IncomingHistoryService.kt
@@ -33,7 +33,6 @@ class IncomingHistoryService(
         unit = this.unit,
         quantity = this.stock.minimalUnit * this.unit,
         is_nisa = this.isNisa,
-        status = this.status,
         minimalUnit = this.stock.minimalUnit
     )
 

--- a/backend/modules/stock/src/main/kotlin/com/example/stock/service/ProfitLossService.kt
+++ b/backend/modules/stock/src/main/kotlin/com/example/stock/service/ProfitLossService.kt
@@ -1,6 +1,5 @@
 package com.example.stock.service
 
-import com.example.stock.model.LotStatus
 import com.example.stock.model.StockLot
 import com.example.stock.model.TransactionType
 import com.example.stock.provider.FinanceProvider
@@ -76,11 +75,6 @@ class ProfitLossService(
 
     private fun calculateUnrealizedPlForLot(lot: StockLot): BigDecimal {
         // 指定ロットの含み損益を計算
-        if (lot.status == LotStatus.SOLD) {
-            return BigDecimal.ZERO
-            // 既に売却済みの場合は0を返す
-        }
-
         val transactions = transactionRepository.findByStockLotId(lot.id)
         // ロットに紐づく全トランザクションを取得
         val buyTransaction = transactions.firstOrNull { it.type == TransactionType.BUY }

--- a/backend/modules/stock/src/main/kotlin/com/example/stock/service/StockLotQueryService.kt
+++ b/backend/modules/stock/src/main/kotlin/com/example/stock/service/StockLotQueryService.kt
@@ -2,7 +2,6 @@ package com.example.stock.service
 
 import com.example.stock.dto.StockLotDTO
 import com.example.stock.dto.StockLotDetailResponse
-import com.example.stock.model.LotStatus
 import com.example.stock.model.StockLot
 import com.example.stock.model.TransactionType
 import com.example.stock.repository.StockLotRepository
@@ -30,7 +29,6 @@ class StockLotQueryService(
             unit = this.unit,
             quantity = this.unit * this.stock.minimalUnit,
             is_nisa = this.isNisa,
-            status = this.status,
             minimalUnit = this.stock.minimalUnit,
         )
     }
@@ -50,7 +48,7 @@ class StockLotQueryService(
      * @return NISA区分をキー、StockLotDTOのリストを値とするマップ
      */
     fun findHoldingStockLots(): Map<Boolean, List<StockLotDTO>> {
-        return stockLotRepository.findByStatus(LotStatus.HOLDING)
+        return stockLotRepository.findAll()
             .map { it.toDto() }
             .groupBy { it.is_nisa }
     }
@@ -62,7 +60,7 @@ class StockLotQueryService(
      * @return NISA区分をキー、StockLotDTOのリストを値とするマップ
      */
     fun findHoldingStockLotsByOwner(ownerId: Int): Map<Boolean, List<StockLotDTO>> {
-        return stockLotRepository.findByOwnerIdAndStatus(ownerId, LotStatus.HOLDING)
+        return stockLotRepository.findByOwnerId(ownerId)
             .map { it.toDto() }
             .groupBy { it.is_nisa }
     }

--- a/backend/modules/stock/src/main/kotlin/com/example/stock/service/StockLotService.kt
+++ b/backend/modules/stock/src/main/kotlin/com/example/stock/service/StockLotService.kt
@@ -1,6 +1,5 @@
 package com.example.stock.service
 
-import com.example.stock.model.LotStatus
 import com.example.stock.model.Owner
 import com.example.stock.model.Stock
 import com.example.stock.model.StockLot
@@ -18,22 +17,13 @@ class StockLotService(
     private val stockLotRepository: StockLotRepository
 ) {
     /**
-     * 所有者IDとステータスによって株式ロットを検索します。
+     * 所有者IDによって株式ロットを検索します。
      *
      * @param ownerId 所有者ID
-     * @param status ロットのステータス (オプション)
      * @return StockLotのリスト
      */
-    // statusはオプションパラメータとして渡される
-    fun findByOwnerId(ownerId: Int, status: String?): List<StockLot> {
-        return if (status != null) {
-            // statusが指定されていれば、新しいメソッドを呼び出す
-            val lotStatus = LotStatus.valueOf(status.uppercase())
-            stockLotRepository.findByOwnerIdAndStatus(ownerId, lotStatus)
-        } else {
-            // statusがなければ、既存のメソッドを呼び出す
-            stockLotRepository.findByOwnerId(ownerId)
-        }
+    fun findByOwnerId(ownerId: Int): List<StockLot> {
+        return stockLotRepository.findByOwnerId(ownerId)
     }
 
     /**

--- a/backend/modules/stock/src/main/kotlin/com/example/stock/service/TransactionService.kt
+++ b/backend/modules/stock/src/main/kotlin/com/example/stock/service/TransactionService.kt
@@ -99,8 +99,7 @@ class TransactionService(
 
             // Mark the lot as sold
             // ロットの状態をSOLDに更新
-            val soldStockLot = stockLot.copy(status = com.example.stock.model.LotStatus.SOLD)
-            stockLotRepository.save(soldStockLot)
+            stockLotRepository.delete(stockLot)
         }
 
         // DTOリストで返却

--- a/backend/modules/stock/src/test/kotlin/com/example/stock/service/ProfitLossServiceTest.kt
+++ b/backend/modules/stock/src/test/kotlin/com/example/stock/service/ProfitLossServiceTest.kt
@@ -48,7 +48,7 @@ class ProfitLossServiceTest {
         // 50株を1単元とする
         val stock = Stock(id = 1, code = "1234", name = "Test Stock", current_price = 1500.0, minimalUnit = 50)
         // 2単元（100株）保有
-        val lot = StockLot(id = 1, owner = owner, stock = stock, unit = 2, status = LotStatus.HOLDING)
+        val lot = StockLot(id = 1, owner = owner, stock = stock, unit = 2)
 
         // 売買トランザクションを作成
         // 2単元（100株）購入

--- a/backend/modules/stock/src/test/kotlin/com/example/stock/service/TransactionServiceTest.kt
+++ b/backend/modules/stock/src/test/kotlin/com/example/stock/service/TransactionServiceTest.kt
@@ -99,7 +99,6 @@ class TransactionServiceTest {
         whenever(stockRepository.findByCode(stock.code)).thenReturn(stock)
         whenever(stockLotRepository.findById(stockLot.id)).thenReturn(Optional.of(stockLot))
         whenever(transactionRepository.save(any())).thenAnswer { it.getArgument(0) }
-        whenever(stockLotRepository.save(any())).thenAnswer { it.getArgument(0) }
 
         // when
         val result = transactionService.createTransaction(request)


### PR DESCRIPTION
This commit removes the `LotStatus` enum and the associated `status` field from the `StockLot` entity. The concept of a lot being "HOLDING" or "SOLD" has been removed from the data model.

Key changes include:
- Deleted the `LotStatus` enum.
- Removed the `status` field from `StockLot` and related DTOs (`StockLotDTO`, `HoldingInfoDTO`).
- Updated `TransactionService` to delete a `StockLot` record when a "SELL" transaction is processed. This ensures that only currently held lots remain in the database.
- Refactored `StockLotRepository`, `StockLotQueryService`, `ProfitLossService`, and other services to remove dependencies on `LotStatus`.
- Updated all relevant tests to align with the new logic.