### PR TITLE
fix(frontend): Correctly display nested stock price data

### DIFF
--- a/frontend/mock/stock.js
+++ b/frontend/mock/stock.js
@@ -16,9 +16,11 @@ let stocks = Mock.mock({
     'id|+1': 1, // IDを1からインクリメント
     'code': '@string("number", 3, 5)', // 3文字から5文字の数字でコードを生成
     'name': '@word(3, 5)', // 3〜5文字の単語で商品名を生成
-    'current_price': '@float(100, 1000, 2, 2)', // 100〜1000の浮動小数点数で現在価格を生成（小数点以下2桁）
-    'dividend': '@float(0, 10, 2, 2)', // 0〜10の浮動小数点数で配当を生成（小数点以下2桁）
-    'earnings_date': '@date("yyyy-MM-dd")', // YYYY-MM-DD形式でリリース日を生成
+    'stock_price': {
+      'current_price': '@float(100, 1000, 2, 2)', // 100〜1000の浮動小数点数で現在価格を生成（小数点以下2桁）
+      'dividend': '@float(0, 10, 2, 2)', // 0〜10の浮動小数点数で配当を生成（小数点以下2桁）
+      'earnings_date': '@date("yyyy-MM-dd")', // YYYY-MM-DD形式でリリース日を生成
+    },
     'sector_id|1': mockSectors.map(s => s.id), // mockSectorsからランダムにIDを選択
   }]
 }).list;
@@ -101,9 +103,11 @@ export default [
       const stock = stocks.find(s => s.code === code);
       if (stock) {
         // 株価、配当、業績発表日をランダムに更新
-        stock.current_price = Mock.Random.float(100, 1000, 2, 2);
-        stock.dividend = Mock.Random.float(0, 10, 2, 2);
-        stock.earnings_date = Mock.mock('@date("yyyy-MM-dd")');
+        stock.stock_price = {
+          current_price: Mock.Random.float(100, 1000, 2, 2),
+          dividend: Mock.Random.float(0, 10, 2, 2),
+          earnings_date: Mock.mock('@date("yyyy-MM-dd")'),
+        };
         return stock;
       }
       // 在庫が見つからない場合はエラーを返す

--- a/frontend/src/views/stock/List.vue
+++ b/frontend/src/views/stock/List.vue
@@ -11,9 +11,9 @@ export default {
     const csvColumns = {
       code: { label: 'コード' },
       name: { label: '名前' },
-      current_price: { label: '現在の株価' },
-      dividend: { label: '配当金' },
-      earnings_date: { label: '業績発表日' },
+      current_price: { label: '現在の株価', formatter: (value, stock) => stock.stock_price.current_price },
+      dividend: { label: '配当金', formatter: (value, stock) => stock.stock_price.dividend },
+      earnings_date: { label: '業績発表日', formatter: (value, stock) => stock.stock_price.earnings_date },
       sector: { label: 'セクター', formatter: (value) => value.name },
     };
 
@@ -88,7 +88,7 @@ export default {
         return this.selectedCsvColumns.map(key => {
           const column = this.csvColumns[key];
           const value = stock[key];
-          return column.formatter ? column.formatter(value) : value;
+          return column.formatter ? column.formatter(value, stock) : value;
         }).join(delimiter);
       });
 

--- a/frontend/src/views/stock/templates/StockList.html
+++ b/frontend/src/views/stock/templates/StockList.html
@@ -48,9 +48,9 @@
         <td><input type="checkbox" :value="stock.code" v-model="selectedStocks"></td>
         <td>{{ stock.code }}</td>
         <td>{{ stock.name }}</td>
-        <td>{{ stock.current_price }}</td>
-        <td>{{ stock.dividend }}</td>
-        <td>{{ stock.earnings_date }}</td>
+        <td>{{ stock.stock_price.current_price }}</td>
+        <td>{{ stock.stock_price.dividend }}</td>
+        <td>{{ stock.stock_price.earnings_date }}</td>
         <td>{{ stock.sector.name }}</td>
         <td>
           <button @click="editStock(stock.id)" class="btn btn-secondary">編集</button>


### PR DESCRIPTION
The stock list page was not displaying the stock price, dividend, and earnings date because the frontend was expecting these properties at the top level of the stock object, while the backend API provides them within a nested `stock_price` object.

This commit aligns the frontend with the backend data structure by:
- Updating the Vue template to access the nested properties (e.g., `stock.stock_price.current_price`).
- Modifying the CSV export functionality to correctly read the nested data.
- Adjusting the mock API data to reflect the nested structure for development and testing.