### PR TITLE
Implement comprehensive unit tests for Yahoo Finance provider

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -29,4 +29,10 @@ subprojects {
             dependency("io.mockk:mockk:1.13.8")
         }
     }
+
+    tasks.withType<Test> {
+        useJUnitPlatform()
+        // 静的モック（MockedStatic）を有効にするための設定
+        jvmArgs("-XX:+EnableDynamicAgentLoading")
+    }
 }

--- a/backend/modules/stock/build.gradle.kts
+++ b/backend/modules/stock/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
     // テスト実行の為、記載が必要(JUnitが内包されている)
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.mockito.kotlin:mockito-kotlin:5.4.0")
+    testImplementation("org.mockito:mockito-inline:5.2.0")
     // サブモジュールで単体テストする為、こちらにも記載している
     testRuntimeOnly("com.h2database:h2")
 }

--- a/backend/modules/stock/src/main/kotlin/com/example/stock/provider/YahooFinanceProvider.kt
+++ b/backend/modules/stock/src/main/kotlin/com/example/stock/provider/YahooFinanceProvider.kt
@@ -1,5 +1,6 @@
 package com.example.stock.provider
 
+import org.jsoup.Connection
 import org.jsoup.Jsoup
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
@@ -8,7 +9,7 @@ import java.time.LocalDate
 import java.util.regex.Pattern
 
 @Component
-class YahooFinanceProvider(
+open class YahooFinanceProvider(
     @Value("\${yahoo.finance.request.delay.millis:1000}")
     private val requestDelayMillis: Long
 ) : FinanceProvider {
@@ -20,13 +21,16 @@ class YahooFinanceProvider(
         private val LOGGER = LoggerFactory.getLogger(YahooFinanceProvider::class.java)
     }
 
+    protected open fun connect(url: String): Connection = Jsoup.connect(url)
+    protected open fun currentDate(): LocalDate = LocalDate.now()
+
     private fun connectWithRetries(url: String, maxAttempts: Int = 3, timeoutMillis: Int = 10000): org.jsoup.nodes.Document? {
         val userAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36"
         var attempt = 0
         while (attempt < maxAttempts) {
             attempt++
             try {
-                val response = Jsoup.connect(url)
+                val response = connect(url)
                     .userAgent(userAgent)
                     .referrer("https://www.google.com")
                     .timeout(timeoutMillis)
@@ -203,7 +207,7 @@ class YahooFinanceProvider(
                         val parts = mmddText.split("/")
                         val month = parts[0].toInt()
                         val day = parts[1].toInt()
-                        val today = LocalDate.now()
+                        val today = currentDate()
                         var date = LocalDate.of(today.year, month, day)
                         if (date.isAfter(today)) {
                             date = date.minusYears(1)
@@ -267,7 +271,7 @@ class YahooFinanceProvider(
             if (matcher3.find()) {
                 val month = matcher3.group(1).toInt()
                 val day = matcher3.group(2).toInt()
-                val currentYear = LocalDate.now().year
+                val currentYear = currentDate().year
                 return LocalDate.of(currentYear, month, day)
             }
             

--- a/backend/modules/stock/src/test/kotlin/com/example/stock/provider/YahooFinanceProviderTest.kt
+++ b/backend/modules/stock/src/test/kotlin/com/example/stock/provider/YahooFinanceProviderTest.kt
@@ -19,8 +19,12 @@ class YahooFinanceProviderTest {
     private lateinit var disclosureDoc: Document
     private lateinit var mockedJsoup: MockedStatic<Jsoup>
     private lateinit var mockedLocalDate: MockedStatic<LocalDate>
-    private val connection: Connection = mock(Connection::class.java)
-    private val disclosureConnection: Connection = mock(Connection::class.java)
+
+    // Use RETURNS_SELF to mock Jsoup's fluent API chain cleanly
+    private val connection: Connection = mock(Connection::class.java, RETURNS_SELF)
+    private val disclosureConnection: Connection = mock(Connection::class.java, RETURNS_SELF)
+    private val response: Connection.Response = mock(Connection.Response::class.java)
+    private val disclosureResponse: Connection.Response = mock(Connection.Response::class.java)
 
     @BeforeEach
     fun setUp() {
@@ -30,14 +34,19 @@ class YahooFinanceProviderTest {
         val disclosureHtmlFile = File("src/test/resources/com/example/stock/provider/dummy-yahoo-finance-disclosure.html")
         disclosureDoc = Jsoup.parse(disclosureHtmlFile, "UTF-8", "")
 
+        // Mock Jsoup.connect and its fluent methods
+        `when`(connection.execute()).thenReturn(response)
+        `when`(response.statusCode()).thenReturn(200)
+        `when`(response.parse()).thenReturn(doc)
 
-        // Mock Jsoup.connect to avoid actual network calls
-        `when`(connection.get()).thenReturn(doc)
-        `when`(disclosureConnection.get()).thenReturn(disclosureDoc)
-        mockedJsoup = mockStatic(Jsoup::class.java)
+        `when`(disclosureConnection.execute()).thenReturn(disclosureResponse)
+        `when`(disclosureResponse.statusCode()).thenReturn(200)
+        `when`(disclosureResponse.parse()).thenReturn(disclosureDoc)
+
+        // Mock Jsoup class statically, but allow other static methods like Jsoup.parse() to run real methods
+        mockedJsoup = mockStatic(Jsoup::class.java, CALLS_REAL_METHODS)
         mockedJsoup.`when`<Connection> { Jsoup.connect(argThat { it.endsWith("/disclosure") }) }.thenReturn(disclosureConnection)
         mockedJsoup.`when`<Connection> { Jsoup.connect(argThat { !it.endsWith("/disclosure") }) }.thenReturn(connection)
-
 
         // Mock LocalDate.now()
         val fixedDate = LocalDate.of(2026, 1, 16)
@@ -58,7 +67,7 @@ class YahooFinanceProviderTest {
         assertEquals(1234.5, stockInfo?.price)
         assertEquals(50.0, stockInfo?.incoming)
         assertEquals(LocalDate.of(2025, 10, 31), stockInfo?.earningsDate)
-        // Note: latestDisclosureDate is now tested in dedicated tests
+        assertEquals(LocalDate.of(2025, 11, 12), stockInfo?.latestDisclosureDate)
     }
 
     @Test
@@ -69,11 +78,8 @@ class YahooFinanceProviderTest {
 
     @Test
     fun `toDoubleOrNull should return null when text is ---`() {
-        // Test that the "---" string correctly converts to null
         val text = "---"
         val result = text.toDoubleOrNull()
-        
-        // Verify that "---" is correctly parsed as null
         assertNull(result, "The text '---' should convert to null")
     }
 
@@ -96,10 +102,159 @@ class YahooFinanceProviderTest {
             </body></html>
         """
         val pastDateDoc = Jsoup.parse(pastDateHtml)
-        `when`(disclosureConnection.get()).thenReturn(pastDateDoc)
+        val tempResponse = mock(Connection.Response::class.java)
+        `when`(tempResponse.statusCode()).thenReturn(200)
+        `when`(tempResponse.parse()).thenReturn(pastDateDoc)
+        `when`(disclosureConnection.execute()).thenReturn(tempResponse)
 
         val stockInfo = provider.fetchStockInfo("dummy")
         // The year should be 2026
         assertEquals(LocalDate.of(2026, 1, 15), stockInfo?.latestDisclosureDate)
+    }
+
+    @Test
+    fun `fetchLatestDisclosure should handle time-based disclosure format`() {
+        // A time-based format like "16:31" should use today's MM/DD
+        val timeHtml = """
+            <!DOCTYPE html><html><body>
+            <div class="disclosureList_list"><div class="disclosureList_item">
+            <ul class="DisclosureItem__supplements__1NHJ"><li class="DisclosureItem__supplement__2U1S"><time>16:31</time></li></ul>
+            </div></div>
+            </body></html>
+        """
+        val timeDoc = Jsoup.parse(timeHtml)
+        val tempResponse = mock(Connection.Response::class.java)
+        `when`(tempResponse.statusCode()).thenReturn(200)
+        `when`(tempResponse.parse()).thenReturn(timeDoc)
+        `when`(disclosureConnection.execute()).thenReturn(tempResponse)
+
+        val stockInfo = provider.fetchStockInfo("dummy")
+        // Today is 2026/01/16, so the parsed date should be 2026/01/16
+        assertEquals(LocalDate.of(2026, 1, 16), stockInfo?.latestDisclosureDate)
+    }
+
+    @Test
+    fun `fetchLatestDisclosure should handle other Japanese date formats`() {
+        // Pattern 1: YYYY年MM月DD日
+        val datePattern1Html = """
+            <!DOCTYPE html><html><body>
+            <div class="disclosureList_list"><div class="disclosureList_item">
+            <time>2025年10月28日</time>
+            </div></div>
+            </body></html>
+        """
+        val doc1 = Jsoup.parse(datePattern1Html)
+        val tempResponse1 = mock(Connection.Response::class.java)
+        `when`(tempResponse1.statusCode()).thenReturn(200)
+        `when`(tempResponse1.parse()).thenReturn(doc1)
+        `when`(disclosureConnection.execute()).thenReturn(tempResponse1)
+
+        var stockInfo = provider.fetchStockInfo("dummy")
+        assertEquals(LocalDate.of(2025, 10, 28), stockInfo?.latestDisclosureDate)
+
+        // Pattern 2: YYYY/MM/DD
+        val datePattern2Html = """
+            <!DOCTYPE html><html><body>
+            <div class="disclosureList_list"><div class="disclosureList_item">
+            <time>2024/05/15</time>
+            </div></div>
+            </body></html>
+        """
+        val doc2 = Jsoup.parse(datePattern2Html)
+        val tempResponse2 = mock(Connection.Response::class.java)
+        `when`(tempResponse2.statusCode()).thenReturn(200)
+        `when`(tempResponse2.parse()).thenReturn(doc2)
+        `when`(disclosureConnection.execute()).thenReturn(tempResponse2)
+
+        stockInfo = provider.fetchStockInfo("dummy")
+        assertEquals(LocalDate.of(2024, 5, 15), stockInfo?.latestDisclosureDate)
+
+        // Pattern 3: MM月DD日
+        val datePattern3Html = """
+            <!DOCTYPE html><html><body>
+            <div class="disclosureList_list"><div class="disclosureList_item">
+            <time>11月10日</time>
+            </div></div>
+            </body></html>
+        """
+        val doc3 = Jsoup.parse(datePattern3Html)
+        val tempResponse3 = mock(Connection.Response::class.java)
+        `when`(tempResponse3.statusCode()).thenReturn(200)
+        `when`(tempResponse3.parse()).thenReturn(doc3)
+        `when`(disclosureConnection.execute()).thenReturn(tempResponse3)
+
+        stockInfo = provider.fetchStockInfo("dummy")
+        // Year defaults to current year (2026)
+        assertEquals(LocalDate.of(2026, 11, 10), stockInfo?.latestDisclosureDate)
+    }
+
+    @Test
+    fun `fetchStockInfo should return null when connection fails completely`() {
+        `when`(connection.execute()).thenThrow(RuntimeException("Network error"))
+        val stockInfo = provider.fetchStockInfo("dummy")
+        assertNull(stockInfo)
+    }
+
+    @Test
+    fun `fetchStockInfo should retry on transient HTTP 500 error and succeed`() {
+        val badResponse = mock(Connection.Response::class.java)
+        `when`(badResponse.statusCode()).thenReturn(500)
+
+        // Return HTTP 500 first, then HTTP 200
+        `when`(connection.execute())
+            .thenReturn(badResponse)
+            .thenReturn(response)
+
+        val stockInfo = provider.fetchStockInfo("dummy")
+        assertNotNull(stockInfo)
+        assertEquals(1234.5, stockInfo?.price)
+    }
+
+    @Test
+    fun `fetchStockInfo should correctly extract previousPrice from script tag`() {
+        val scriptHtml = """
+            <!DOCTYPE html><html><head>
+            <title>テスト株式会社【DUMMY】：ダミー情報 - Yahoo!ファイナンス</title>
+            <script>
+            window.__PRELOADED_STATE__ = {
+                "context": {
+                    "dispatcher": {
+                        "stores": {
+                            "QuoteStore": {
+                                "previousPrice":"1200.5"
+                            }
+                        }
+                    }
+                }
+            };
+            </script>
+            </head><body>
+            <span class="PriceBoard__price">1,234.5</span>
+            </body></html>
+        """
+        val scriptDoc = Jsoup.parse(scriptHtml)
+        val tempResponse = mock(Connection.Response::class.java)
+        `when`(tempResponse.statusCode()).thenReturn(200)
+        `when`(tempResponse.parse()).thenReturn(scriptDoc)
+        `when`(connection.execute()).thenReturn(tempResponse)
+
+        val stockInfo = provider.fetchStockInfo("dummy")
+        assertNotNull(stockInfo)
+        assertEquals(1200.5, stockInfo?.previousPrice)
+    }
+
+    @Test
+    fun `fetchStockInfo should handle missing or empty dividend gracefully`() {
+        val noDivHtmlFile = File("src/test/resources/com/example/stock/provider/dummy-yahoo-finance-with-no-dividend.html")
+        val noDivDoc = Jsoup.parse(noDivHtmlFile, "UTF-8", "")
+
+        val tempResponse = mock(Connection.Response::class.java)
+        `when`(tempResponse.statusCode()).thenReturn(200)
+        `when`(tempResponse.parse()).thenReturn(noDivDoc)
+        `when`(connection.execute()).thenReturn(tempResponse)
+
+        val stockInfo = provider.fetchStockInfo("dummy")
+        assertNotNull(stockInfo)
+        assertNull(stockInfo?.incoming, "Dividend/incoming should be null when it is represented as '---'")
     }
 }

--- a/backend/modules/stock/src/test/kotlin/com/example/stock/provider/YahooFinanceProviderTest.kt
+++ b/backend/modules/stock/src/test/kotlin/com/example/stock/provider/YahooFinanceProviderTest.kt
@@ -5,8 +5,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.jsoup.Connection
 import org.jsoup.Jsoup
-import org.mockito.MockedStatic
-import org.mockito.Mockito.*
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -102,9 +100,9 @@ class YahooFinanceProviderTest {
         """
         val pastDateDoc = Jsoup.parse(pastDateHtml)
         val tempResponse = mock(Connection.Response::class.java)
-        `when`(tempResponse.statusCode()).thenReturn(200)
-        `when`(tempResponse.parse()).thenReturn(pastDateDoc)
-        `when`(disclosureConnection.execute()).thenReturn(tempResponse)
+        whenever(tempResponse.statusCode()).thenReturn(200)
+        whenever(tempResponse.parse()).thenReturn(pastDateDoc)
+        whenever(disclosureConnection.execute()).thenReturn(tempResponse)
 
         val stockInfo = provider.fetchStockInfo("dummy")
         // The year should be 2026
@@ -123,9 +121,9 @@ class YahooFinanceProviderTest {
         """
         val timeDoc = Jsoup.parse(timeHtml)
         val tempResponse = mock(Connection.Response::class.java)
-        `when`(tempResponse.statusCode()).thenReturn(200)
-        `when`(tempResponse.parse()).thenReturn(timeDoc)
-        `when`(disclosureConnection.execute()).thenReturn(tempResponse)
+        whenever(tempResponse.statusCode()).thenReturn(200)
+        whenever(tempResponse.parse()).thenReturn(timeDoc)
+        whenever(disclosureConnection.execute()).thenReturn(tempResponse)
 
         val stockInfo = provider.fetchStockInfo("dummy")
         // Today is 2026/01/16, so the parsed date should be 2026/01/16
@@ -144,9 +142,9 @@ class YahooFinanceProviderTest {
         """
         val doc1 = Jsoup.parse(datePattern1Html)
         val tempResponse1 = mock(Connection.Response::class.java)
-        `when`(tempResponse1.statusCode()).thenReturn(200)
-        `when`(tempResponse1.parse()).thenReturn(doc1)
-        `when`(disclosureConnection.execute()).thenReturn(tempResponse1)
+        whenever(tempResponse1.statusCode()).thenReturn(200)
+        whenever(tempResponse1.parse()).thenReturn(doc1)
+        whenever(disclosureConnection.execute()).thenReturn(tempResponse1)
 
         var stockInfo = provider.fetchStockInfo("dummy")
         assertEquals(LocalDate.of(2025, 10, 28), stockInfo?.latestDisclosureDate)
@@ -161,9 +159,9 @@ class YahooFinanceProviderTest {
         """
         val doc2 = Jsoup.parse(datePattern2Html)
         val tempResponse2 = mock(Connection.Response::class.java)
-        `when`(tempResponse2.statusCode()).thenReturn(200)
-        `when`(tempResponse2.parse()).thenReturn(doc2)
-        `when`(disclosureConnection.execute()).thenReturn(tempResponse2)
+        whenever(tempResponse2.statusCode()).thenReturn(200)
+        whenever(tempResponse2.parse()).thenReturn(doc2)
+        whenever(disclosureConnection.execute()).thenReturn(tempResponse2)
 
         stockInfo = provider.fetchStockInfo("dummy")
         assertEquals(LocalDate.of(2024, 5, 15), stockInfo?.latestDisclosureDate)
@@ -178,9 +176,9 @@ class YahooFinanceProviderTest {
         """
         val doc3 = Jsoup.parse(datePattern3Html)
         val tempResponse3 = mock(Connection.Response::class.java)
-        `when`(tempResponse3.statusCode()).thenReturn(200)
-        `when`(tempResponse3.parse()).thenReturn(doc3)
-        `when`(disclosureConnection.execute()).thenReturn(tempResponse3)
+        whenever(tempResponse3.statusCode()).thenReturn(200)
+        whenever(tempResponse3.parse()).thenReturn(doc3)
+        whenever(disclosureConnection.execute()).thenReturn(tempResponse3)
 
         stockInfo = provider.fetchStockInfo("dummy")
         // Year defaults to current year (2026)
@@ -189,7 +187,7 @@ class YahooFinanceProviderTest {
 
     @Test
     fun `fetchStockInfo should return null when connection fails completely`() {
-        `when`(connection.execute()).thenThrow(RuntimeException("Network error"))
+        whenever(connection.execute()).thenThrow(RuntimeException("Network error"))
         val stockInfo = provider.fetchStockInfo("dummy")
         assertNull(stockInfo)
     }
@@ -197,10 +195,10 @@ class YahooFinanceProviderTest {
     @Test
     fun `fetchStockInfo should retry on transient HTTP 500 error and succeed`() {
         val badResponse = mock(Connection.Response::class.java)
-        `when`(badResponse.statusCode()).thenReturn(500)
+        whenever(badResponse.statusCode()).thenReturn(500)
 
         // Return HTTP 500 first, then HTTP 200
-        `when`(connection.execute())
+        whenever(connection.execute())
             .thenReturn(badResponse)
             .thenReturn(response)
 
@@ -233,9 +231,9 @@ class YahooFinanceProviderTest {
         """
         val scriptDoc = Jsoup.parse(scriptHtml)
         val tempResponse = mock(Connection.Response::class.java)
-        `when`(tempResponse.statusCode()).thenReturn(200)
-        `when`(tempResponse.parse()).thenReturn(scriptDoc)
-        `when`(connection.execute()).thenReturn(tempResponse)
+        whenever(tempResponse.statusCode()).thenReturn(200)
+        whenever(tempResponse.parse()).thenReturn(scriptDoc)
+        whenever(connection.execute()).thenReturn(tempResponse)
 
         val stockInfo = provider.fetchStockInfo("dummy")
         assertNotNull(stockInfo)
@@ -248,9 +246,9 @@ class YahooFinanceProviderTest {
         val noDivDoc = Jsoup.parse(noDivHtmlFile, "UTF-8", "")
 
         val tempResponse = mock(Connection.Response::class.java)
-        `when`(tempResponse.statusCode()).thenReturn(200)
-        `when`(tempResponse.parse()).thenReturn(noDivDoc)
-        `when`(connection.execute()).thenReturn(tempResponse)
+        whenever(tempResponse.statusCode()).thenReturn(200)
+        whenever(tempResponse.parse()).thenReturn(noDivDoc)
+        whenever(connection.execute()).thenReturn(tempResponse)
 
         val stockInfo = provider.fetchStockInfo("dummy")
         assertNotNull(stockInfo)

--- a/backend/modules/stock/src/test/kotlin/com/example/stock/provider/YahooFinanceProviderTest.kt
+++ b/backend/modules/stock/src/test/kotlin/com/example/stock/provider/YahooFinanceProviderTest.kt
@@ -7,25 +7,29 @@ import org.junit.jupiter.api.Test
 import org.jsoup.Connection
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import org.mockito.MockedStatic
-import org.mockito.Mockito.*
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 import java.io.File
 import java.time.LocalDate
 
 class YahooFinanceProviderTest {
 
-    private val provider = YahooFinanceProvider(0) // requestDelayMillis = 0
-
-    private fun setupMockConnection(block: (Connection, Connection) -> Unit) {
-val htmlFile = File("src/test/resources/com/example/stock/provider/dummy-yahoo-finance.html")
+    private lateinit var provider: YahooFinanceProvider
+    private lateinit var connection: Connection
+    private lateinit var disclosureConnection: Connection
+    private lateinit var response: Connection.Response
+    private lateinit var disclosureResponse: Connection.Response
+    @BeforeEach
+    fun initMocks() {
+        val htmlFile = File("src/test/resources/com/example/stock/provider/dummy-yahoo-finance.html")
         val doc = Jsoup.parse(htmlFile, "UTF-8", "")
         val disclosureHtmlFile = File("src/test/resources/com/example/stock/provider/dummy-yahoo-finance-disclosure.html")
         val disclosureDoc = Jsoup.parse(disclosureHtmlFile, "UTF-8", "")
 
-        val connection = mock(Connection::class.java, RETURNS_SELF)
-        val disclosureConnection = mock(Connection::class.java, RETURNS_SELF)
-        val response = mock(Connection.Response::class.java)
-        val disclosureResponse = mock(Connection.Response::class.java)
+        connection = mock(Connection::class.java, RETURNS_SELF)
+        disclosureConnection = mock(Connection::class.java, RETURNS_SELF)
+        response = mock(Connection.Response::class.java)
+        disclosureResponse = mock(Connection.Response::class.java)
 
         `when`(connection.execute()).thenReturn(response)
         `when`(response.statusCode()).thenReturn(200)
@@ -35,26 +39,20 @@ val htmlFile = File("src/test/resources/com/example/stock/provider/dummy-yahoo-f
         `when`(disclosureResponse.statusCode()).thenReturn(200)
         `when`(disclosureResponse.parse()).thenReturn(disclosureDoc)
 
-        mockStatic(Jsoup::class.java, CALLS_REAL_METHODS).use { mockedJsoup ->
-            mockedJsoup.`when`<Connection> { Jsoup.connect(argThat { it.endsWith("/disclosure") }) }.thenReturn(disclosureConnection)
-            mockedJsoup.`when`<Connection> { Jsoup.connect(argThat { !it.endsWith("/disclosure") }) }.thenReturn(connection)
-
-            mockStatic(LocalDate::class.java, CALLS_REAL_METHODS).use { mockedLocalDate ->
-                val fixedDate = LocalDate.of(2026, 1, 16)
-                `when`(LocalDate.now()).thenReturn(fixedDate)
-
-                block(connection, disclosureConnection)
+        provider = object : YahooFinanceProvider(0) {
+            override fun connect(url: String): Connection {
+                return if (url.endsWith("/disclosure")) disclosureConnection else connection
             }
+
+            override fun currentDate(): LocalDate = LocalDate.of(2026, 1, 16)
         }
     }
 
     @Test
     fun `fetchLatestDisclosure should return correct date when disclosure date is before or after today`() {
-        setupMockConnection { _, _ ->
-            val stockInfo = provider.fetchStockInfo("dummy")
-            assertNotNull(stockInfo)
-            assertEquals(LocalDate.of(2025, 11, 12), stockInfo?.latestDisclosureDate)
-        }
+        val stockInfo = provider.fetchStockInfo("dummy")
+        assertNotNull(stockInfo)
+        assertEquals(LocalDate.of(2025, 11, 12), stockInfo?.latestDisclosureDate)
     }
 
     @Test

--- a/backend/modules/stock/src/test/kotlin/com/example/stock/provider/YahooFinanceProviderTest.kt
+++ b/backend/modules/stock/src/test/kotlin/com/example/stock/provider/YahooFinanceProviderTest.kt
@@ -99,7 +99,7 @@ class YahooFinanceProviderTest {
             </body></html>
         """
         val pastDateDoc = Jsoup.parse(pastDateHtml)
-        val tempResponse = mock(Connection.Response::class.java)
+        val tempResponse: Connection.Response = mock()
         whenever(tempResponse.statusCode()).thenReturn(200)
         whenever(tempResponse.parse()).thenReturn(pastDateDoc)
         whenever(disclosureConnection.execute()).thenReturn(tempResponse)
@@ -120,7 +120,7 @@ class YahooFinanceProviderTest {
             </body></html>
         """
         val timeDoc = Jsoup.parse(timeHtml)
-        val tempResponse = mock(Connection.Response::class.java)
+        val tempResponse: Connection.Response = mock()
         whenever(tempResponse.statusCode()).thenReturn(200)
         whenever(tempResponse.parse()).thenReturn(timeDoc)
         whenever(disclosureConnection.execute()).thenReturn(tempResponse)
@@ -141,7 +141,7 @@ class YahooFinanceProviderTest {
             </body></html>
         """
         val doc1 = Jsoup.parse(datePattern1Html)
-        val tempResponse1 = mock(Connection.Response::class.java)
+        val tempResponse1: Connection.Response = mock()
         whenever(tempResponse1.statusCode()).thenReturn(200)
         whenever(tempResponse1.parse()).thenReturn(doc1)
         whenever(disclosureConnection.execute()).thenReturn(tempResponse1)
@@ -158,7 +158,7 @@ class YahooFinanceProviderTest {
             </body></html>
         """
         val doc2 = Jsoup.parse(datePattern2Html)
-        val tempResponse2 = mock(Connection.Response::class.java)
+        val tempResponse2: Connection.Response = mock()
         whenever(tempResponse2.statusCode()).thenReturn(200)
         whenever(tempResponse2.parse()).thenReturn(doc2)
         whenever(disclosureConnection.execute()).thenReturn(tempResponse2)
@@ -175,7 +175,7 @@ class YahooFinanceProviderTest {
             </body></html>
         """
         val doc3 = Jsoup.parse(datePattern3Html)
-        val tempResponse3 = mock(Connection.Response::class.java)
+        val tempResponse3: Connection.Response = mock()
         whenever(tempResponse3.statusCode()).thenReturn(200)
         whenever(tempResponse3.parse()).thenReturn(doc3)
         whenever(disclosureConnection.execute()).thenReturn(tempResponse3)
@@ -194,7 +194,7 @@ class YahooFinanceProviderTest {
 
     @Test
     fun `fetchStockInfo should retry on transient HTTP 500 error and succeed`() {
-        val badResponse = mock(Connection.Response::class.java)
+        val badResponse: Connection.Response = mock()
         whenever(badResponse.statusCode()).thenReturn(500)
 
         // Return HTTP 500 first, then HTTP 200
@@ -230,7 +230,7 @@ class YahooFinanceProviderTest {
             </body></html>
         """
         val scriptDoc = Jsoup.parse(scriptHtml)
-        val tempResponse = mock(Connection.Response::class.java)
+        val tempResponse: Connection.Response = mock()
         whenever(tempResponse.statusCode()).thenReturn(200)
         whenever(tempResponse.parse()).thenReturn(scriptDoc)
         whenever(connection.execute()).thenReturn(tempResponse)
@@ -245,7 +245,7 @@ class YahooFinanceProviderTest {
         val noDivHtmlFile = File("src/test/resources/com/example/stock/provider/dummy-yahoo-finance-with-no-dividend.html")
         val noDivDoc = Jsoup.parse(noDivHtmlFile, "UTF-8", "")
 
-        val tempResponse = mock(Connection.Response::class.java)
+        val tempResponse: Connection.Response = mock()
         whenever(tempResponse.statusCode()).thenReturn(200)
         whenever(tempResponse.parse()).thenReturn(noDivDoc)
         whenever(connection.execute()).thenReturn(tempResponse)

--- a/backend/modules/stock/src/test/kotlin/com/example/stock/provider/YahooFinanceProviderTest.kt
+++ b/backend/modules/stock/src/test/kotlin/com/example/stock/provider/YahooFinanceProviderTest.kt
@@ -26,12 +26,6 @@ class YahooFinanceProviderTest {
         val disclosureHtmlFile = File("src/test/resources/com/example/stock/provider/dummy-yahoo-finance-disclosure.html")
         val disclosureDoc = Jsoup.parse(disclosureHtmlFile, "UTF-8", "")
 
-        connection = mock {
-            on { execute() } doReturn response
-        }
-        disclosureConnection = mock {
-            on { execute() } doReturn disclosureResponse
-        }
         response = mock {
             on { statusCode() } doReturn 200
             on { parse() } doReturn doc
@@ -39,6 +33,12 @@ class YahooFinanceProviderTest {
         disclosureResponse = mock {
             on { statusCode() } doReturn 200
             on { parse() } doReturn disclosureDoc
+        }
+        connection = mock {
+            on { execute() } doReturn response
+        }
+        disclosureConnection = mock {
+            on { execute() } doReturn disclosureResponse
         }
 
         provider = object : YahooFinanceProvider(0) {

--- a/backend/modules/stock/src/test/kotlin/com/example/stock/provider/YahooFinanceProviderTest.kt
+++ b/backend/modules/stock/src/test/kotlin/com/example/stock/provider/YahooFinanceProviderTest.kt
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.jsoup.Connection
 import org.jsoup.Jsoup
+import org.mockito.MockedStatic
+import org.mockito.Mockito.*
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever

--- a/backend/modules/stock/src/test/kotlin/com/example/stock/provider/YahooFinanceProviderTest.kt
+++ b/backend/modules/stock/src/test/kotlin/com/example/stock/provider/YahooFinanceProviderTest.kt
@@ -1,12 +1,11 @@
 package com.example.stock.provider
 
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.jsoup.Connection
 import org.jsoup.Jsoup
-import org.jsoup.nodes.Document
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import java.io.File
@@ -19,6 +18,7 @@ class YahooFinanceProviderTest {
     private lateinit var disclosureConnection: Connection
     private lateinit var response: Connection.Response
     private lateinit var disclosureResponse: Connection.Response
+
     @BeforeEach
     fun initMocks() {
         val htmlFile = File("src/test/resources/com/example/stock/provider/dummy-yahoo-finance.html")
@@ -26,18 +26,20 @@ class YahooFinanceProviderTest {
         val disclosureHtmlFile = File("src/test/resources/com/example/stock/provider/dummy-yahoo-finance-disclosure.html")
         val disclosureDoc = Jsoup.parse(disclosureHtmlFile, "UTF-8", "")
 
-        connection = mock(Connection::class.java, RETURNS_SELF)
-        disclosureConnection = mock(Connection::class.java, RETURNS_SELF)
-        response = mock(Connection.Response::class.java)
-        disclosureResponse = mock(Connection.Response::class.java)
-
-        `when`(connection.execute()).thenReturn(response)
-        `when`(response.statusCode()).thenReturn(200)
-        `when`(response.parse()).thenReturn(doc)
-
-        `when`(disclosureConnection.execute()).thenReturn(disclosureResponse)
-        `when`(disclosureResponse.statusCode()).thenReturn(200)
-        `when`(disclosureResponse.parse()).thenReturn(disclosureDoc)
+        connection = mock {
+            on { execute() } doReturn response
+        }
+        disclosureConnection = mock {
+            on { execute() } doReturn disclosureResponse
+        }
+        response = mock {
+            on { statusCode() } doReturn 200
+            on { parse() } doReturn doc
+        }
+        disclosureResponse = mock {
+            on { statusCode() } doReturn 200
+            on { parse() } doReturn disclosureDoc
+        }
 
         provider = object : YahooFinanceProvider(0) {
             override fun connect(url: String): Connection {

--- a/backend/modules/stock/src/test/kotlin/com/example/stock/provider/YahooFinanceProviderTest.kt
+++ b/backend/modules/stock/src/test/kotlin/com/example/stock/provider/YahooFinanceProviderTest.kt
@@ -14,27 +14,19 @@ import java.time.LocalDate
 
 class YahooFinanceProviderTest {
 
-    private lateinit var provider: YahooFinanceProvider
-    private lateinit var doc: Document
-    private lateinit var disclosureDoc: Document
-    private lateinit var mockedJsoup: MockedStatic<Jsoup>
-    private lateinit var mockedLocalDate: MockedStatic<LocalDate>
+    private val provider = YahooFinanceProvider(0) // requestDelayMillis = 0
 
-    // Use RETURNS_SELF to mock Jsoup's fluent API chain cleanly
-    private val connection: Connection = mock(Connection::class.java, RETURNS_SELF)
-    private val disclosureConnection: Connection = mock(Connection::class.java, RETURNS_SELF)
-    private val response: Connection.Response = mock(Connection.Response::class.java)
-    private val disclosureResponse: Connection.Response = mock(Connection.Response::class.java)
-
-    @BeforeEach
-    fun setUp() {
-        provider = YahooFinanceProvider(0) // requestDelayMillis = 0
-        val htmlFile = File("src/test/resources/com/example/stock/provider/dummy-yahoo-finance.html")
-        doc = Jsoup.parse(htmlFile, "UTF-8", "")
+    private fun setupMockConnection(block: (Connection, Connection) -> Unit) {
+val htmlFile = File("src/test/resources/com/example/stock/provider/dummy-yahoo-finance.html")
+        val doc = Jsoup.parse(htmlFile, "UTF-8", "")
         val disclosureHtmlFile = File("src/test/resources/com/example/stock/provider/dummy-yahoo-finance-disclosure.html")
-        disclosureDoc = Jsoup.parse(disclosureHtmlFile, "UTF-8", "")
+        val disclosureDoc = Jsoup.parse(disclosureHtmlFile, "UTF-8", "")
 
-        // Mock Jsoup.connect and its fluent methods
+        val connection = mock(Connection::class.java, RETURNS_SELF)
+        val disclosureConnection = mock(Connection::class.java, RETURNS_SELF)
+        val response = mock(Connection.Response::class.java)
+        val disclosureResponse = mock(Connection.Response::class.java)
+
         `when`(connection.execute()).thenReturn(response)
         `when`(response.statusCode()).thenReturn(200)
         `when`(response.parse()).thenReturn(doc)
@@ -43,21 +35,26 @@ class YahooFinanceProviderTest {
         `when`(disclosureResponse.statusCode()).thenReturn(200)
         `when`(disclosureResponse.parse()).thenReturn(disclosureDoc)
 
-        // Mock Jsoup class statically, but allow other static methods like Jsoup.parse() to run real methods
-        mockedJsoup = mockStatic(Jsoup::class.java, CALLS_REAL_METHODS)
-        mockedJsoup.`when`<Connection> { Jsoup.connect(argThat { it.endsWith("/disclosure") }) }.thenReturn(disclosureConnection)
-        mockedJsoup.`when`<Connection> { Jsoup.connect(argThat { !it.endsWith("/disclosure") }) }.thenReturn(connection)
+        mockStatic(Jsoup::class.java, CALLS_REAL_METHODS).use { mockedJsoup ->
+            mockedJsoup.`when`<Connection> { Jsoup.connect(argThat { it.endsWith("/disclosure") }) }.thenReturn(disclosureConnection)
+            mockedJsoup.`when`<Connection> { Jsoup.connect(argThat { !it.endsWith("/disclosure") }) }.thenReturn(connection)
 
-        // Mock LocalDate.now()
-        val fixedDate = LocalDate.of(2026, 1, 16)
-        mockedLocalDate = mockStatic(LocalDate::class.java, CALLS_REAL_METHODS)
-        `when`(LocalDate.now()).thenReturn(fixedDate)
+            mockStatic(LocalDate::class.java, CALLS_REAL_METHODS).use { mockedLocalDate ->
+                val fixedDate = LocalDate.of(2026, 1, 16)
+                `when`(LocalDate.now()).thenReturn(fixedDate)
+
+                block(connection, disclosureConnection)
+            }
+        }
     }
 
-    @AfterEach
-    fun tearDown() {
-        mockedJsoup.close()
-        mockedLocalDate.close()
+    @Test
+    fun `fetchLatestDisclosure should return correct date when disclosure date is before or after today`() {
+        setupMockConnection { _, _ ->
+            val stockInfo = provider.fetchStockInfo("dummy")
+            assertNotNull(stockInfo)
+            assertEquals(LocalDate.of(2025, 11, 12), stockInfo?.latestDisclosureDate)
+        }
     }
 
     @Test

--- a/compose.test.yml
+++ b/compose.test.yml
@@ -1,0 +1,13 @@
+services:
+  backend:
+    ports: []
+    volumes:
+      # カレントディレクトリの backend をコンテナの /app にマウント
+      - ./StockManager/backend:/app
+      - gradle-cache:/root/.gradle
+    working_dir: /app
+    entrypoint: []
+
+volumes:
+  gradle-cache:
+

--- a/test-exec-single.sh
+++ b/test-exec-single.sh
@@ -1,0 +1,5 @@
+# クラス単位で絞り込んで実行
+# TEST="YahooProviderTest"
+# ./test-exec-single.sh $TEST
+sudo docker compose -f compose.yml -f compose.test.yml run --rm backend ./gradlew test --tests $1 --no-daemon
+

--- a/test-exec.sh
+++ b/test-exec.sh
@@ -1,0 +1,2 @@
+sudo docker compose -f compose.yml -f compose.test.yml run --rm backend ./gradlew test
+


### PR DESCRIPTION
Implemented comprehensive unit tests for YahooFinanceProvider to test financial and stock data extraction logic, including Japanese date patterns, compact script tags, dividend placeholders, and connection retries.

---
*PR created automatically by Jules for task [15189839309453505078](https://jules.google.com/task/15189839309453505078) started by @ijikeman*